### PR TITLE
feat: Add terminate chan at once Issue #16

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -1,23 +1,26 @@
 package client
 
 import (
-	"github.com/gorilla/websocket"
-	"github.com/jjwow73/MeerChat/pkg/chat"
 	"log"
 	"os"
 	"os/signal"
+
+	"github.com/gorilla/websocket"
+	"github.com/jjwow73/MeerChat/pkg/chat"
 )
 
 type admin struct {
 	connections       map[string]*connection
 	outputChannel     chan *connectionMessage
 	focusedConnection *connection
+	done              chan bool
 }
 
 func newAdmin() *admin {
 	return &admin{
 		connections:   make(map[string]*connection),
 		outputChannel: make(chan *connectionMessage),
+		done:          make(chan bool),
 	}
 }
 

--- a/pkg/client/cuiKeybinding.go
+++ b/pkg/client/cuiKeybinding.go
@@ -5,6 +5,7 @@ import (
 )
 
 func quit(g *gocui.Gui, v *gocui.View) error {
+	a.done <- true
 	return gocui.ErrQuit
 }
 func keybindings(g *gocui.Gui) error {

--- a/pkg/client/rpc.go
+++ b/pkg/client/rpc.go
@@ -51,9 +51,15 @@ func RpcStart() {
 	i := new(Intermediate)
 	rpc.Register(i)
 	rpc.HandleHTTP()
+
 	l, e := net.Listen("tcp", ":12039")
+	defer l.Close()
+
 	if e != nil {
 		log.Fatal("listen error:", e)
 	}
-	http.Serve(l, nil)
+
+	go http.Serve(l, nil)
+
+	<-a.done
 }


### PR DESCRIPTION
한번에 rpcStart 함수와 cuiMain함수의 동시 종료를 구현.
기존에는 Ctrl+C를 두번 눌러야 종료됐고 번거로움.

- [x] 종료를 위한 Channel 생성
- [x] Cui에서 ctrl+C 감지되면 chan <- signal
- [x] rpcStart에서 <-signal 시 종료.
- Issue #16